### PR TITLE
Update adobject.py - minor improvement to Unicode handling in group names

### DIFF
--- a/pyad/adobject.py
+++ b/pyad/adobject.py
@@ -172,7 +172,7 @@ class ADObject(ADBase):
         return hash(self.guid)
 
     def __str__(self):
-        return "<%s '%s'>" % (self.__class__.__name__, self.dn)
+        return u"<%s '%s'>" % (self.__class__.__name__, self.dn)
 
     __repr__ = __str__
 


### PR DESCRIPTION
pyad.from_cn(u"SomeGroupWithAnEMDash – OrOtherUnicodeCharracter")
Traceback (most recent call last):
  File "<pyshell#54>", line 1, in <module>
    pyad.from_cn(u"SomeGroupWithAnEMDash – OrOtherUnicodeCharracter")
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 33: ordinal not in range(128)

Caused by attempting to return __str__(self) to the console as an ASCII text string containing Unicode characters

