### PR TITLE
Better Handling for LDAP Special Charracters

### DIFF
--- a/pyad/pyad.py
+++ b/pyad/pyad.py
@@ -3,6 +3,8 @@ from pyadexceptions import InvalidObjectException, invalidResults
 import aduser, adcomputer, addomain, addomain, adgroup, adobject, pyadconstants, adcontainer
 
 def from_cn(common_name, search_base=None, options={}):
+    Escape = {"\\":"\\5C","*":"\\2A","(":"\\28",")":"\\29"}
+    common_name = "".join([Escape.get(char, char) for char in common_name])
     try:
         q = ADObject.from_cn(common_name, search_base, options)
         q.adjust_pyad_type()
@@ -11,6 +13,8 @@ def from_cn(common_name, search_base=None, options={}):
         return None
 
 def from_dn(distinguished_name, options={}):
+    Escape = {"\\":"\\5C","*":"\\2A","(":"\\28",")":"\\29"}
+    distinguished_name = "".join([Escape.get(char, char) for char in distinguished_name])
     try:
         q = ADObject.from_dn(distinguished_name,options)
         q.adjust_pyad_type()


### PR DESCRIPTION
fixes issues with open brackets and other ldap special characters 

Traceback (most recent call last):
  File "<pyshell#9>", line 1, in <module>
    g = pyad.from_cn("SOMETHING_WITH_AN_OPEN_BRACKET ( ")
  File "C:\Python27\lib\site-packages\pyad\pyad.py", line 14, in from_cn
    q = ADObject.from_cn(common_name, search_base, options)
  File "C:\Python27\lib\site-packages\pyad\adobject.py", line 134, in from_cn
    return cls(adsearch.by_cn(cn, search_base, options), None, options)
  File "C:\Python27\lib\site-packages\pyad\adsearch.py", line 16, in by_cn
    type="GC")
  File "C:\Python27\lib\site-packages\pyad\adquery.py", line 65, in execute_query
    self.__rs, self.__rc = command.Execute()
  File "<COMObject ADODB.Command>", line 3, in Execute
  File "C:\Python27\lib\site-packages\win32com\client\dynamic.py", line 282, in _ApplyTypes_
    result = self._oleobj_.InvokeTypes(*(dispid, LCID, wFlags, retType, argTypes) + args)
com_error: (-2147352567, 'Exception occurred.', (0, u'Provider', u'One or more errors occurred during processing of command.', None, 1240640, -2147217900), None)