### PR TITLE
Changing the quotes in the README.rst file, fixing issue #42

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ pyad is a Python library designed to provide a simple, Pythonic interface to Act
 
 
 Requirements
-============		
+============
 
 pyad requires pywin32, available at http://sourceforge.net/projects/pywin32.
 
@@ -27,7 +27,7 @@ However, it is possible to connect to a specific domain controller or to use alt
 
 
 It is also possible to pass in options when connecting to a specific object. This will not set the library defaults, but these settings will be used from any objects you derive from it (e.g. if you request group membership of a user) Example::
-   
+
    from pyad import aduser
    user = aduser.ADUser.from_cn("myuser", options=dict(ldap_server="dc1.domain.com"))
 
@@ -54,13 +54,13 @@ It is also possible to use the pyad factory with an arbitrary Active Directory o
 
 
 Unlike the ADSI interface, pyad objects are intended to interact with one another. Instead of adding the DN of a user to the members attribute of a group to add the user, you instead add the user object to the group. For instance::
-    
+
     user1 = ADUser.from_cn("myuser1")
     user2 = ADUser.from_cn("myuser2")
     group = ADGroup.from_dn("staff")
-    
+
     group.add_members([user1, user2])
-    
+
     for user in group.get_members():
         print user1.description
 
@@ -72,7 +72,7 @@ However, it is still possible to directly manipulate any attribute outside of th
     user.append_to_attribute("member", "cn=myuser1, ou=staff, dc=domain, dc=com")
 
 
-More details on how to manipulate the objects you find to is found in the next section. 
+More details on how to manipulate the objects you find to is found in the next section.
 
 
 Creating, Moving, and Deleting Objects
@@ -81,10 +81,10 @@ Creating, Moving, and Deleting Objects
 There are two methodologies for creating and deleting objects. In both cases, you must first bind to the parent container. When creating a new object, several attributes are required, but other additional attributes can be specified with the `optional_attributes` parameter. Example 1::
 
     ou = ADContainer.from_dn("ou=workstations, dc=domain, dc=com")
-    
+
     # create a new group without any optional attributes
     new_computer = ADComputer.create("WS-489", ou)
-    
+
     # create a new group with additional attributes
     new_group = ADGroup.create("IT-STAFF", security_enabled=True, scope='UNIVERSAL',
                     optional_attributes = {"description":"all IT staff in our company"})
@@ -93,21 +93,21 @@ It is also possible to create new objects from the parent container::
 
     ou = ADContainer.from_dn("ou=workstations, dc=domain, dc=com")
     computer = ou.create_computer("WS-490")
-    
+
 Once objects are created, they can be moved::
 
     computer = ADComputer.from_cn("WS-500")
     computer.move(ADContainer.from_dn("ou=workstations, ou=HR, dc=company, dc=com"))
-    
+
 or renamed::
 
     computer = ADComputer.from_cn("WS-500")
     computer.rename("WS-501")
-    
+
 Objects can be removed by calling delete()::
 
     ADComputer.from_cn("WS-500").delete()
-    
+
 
 Searching Active Directory
 ==========================
@@ -116,20 +116,19 @@ As shown above, objects can be directly connected to via CN, DN, GUID, or UPN. H
 
     import pyad.adquery
     q = pyad.adquery.ADQuery()
-    
+
     q.execute_query(
         attributes = ["distinguishedName", "description"],
         where_clause = "objectClass = '*'",
         base_dn = "OU=users, DC=domain, DC=com"
     )
-    
+
     for row in q.get_results():
         print row["distinguishedName"]
 
 License
 =======
 
-pyad is licensed under the Apache License, Version 2.0 (the “License”). You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+pyad is licensed under the Apache License, Version 2.0 (the "License"). You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
Fixed the quotes on the Readme.rst file so that "pip install pyad" does not throw UnicodeDecodeError error in windows.

Please review