### PR TITLE
Remove pywin32 from requires and suggest pypiwin32

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,12 @@ Requirements
 
 pyad requires pywin32, available at http://sourceforge.net/projects/pywin32.
 
+Alternatively,
+::
+    pip install pypiwin32
+
+works as well.
+
 
 Connecting to Active Directory
 ==============================

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     ],
     install_requires=[
         'setuptools',
-        'pywin32',
         'future'
     ]
 )


### PR DESCRIPTION
pywin32 has no use but blocking automatic building in the requires as pywin32 cannot be installed with pip; pypiwin32 is in-favored for varies reasons.  But commonly, we will just let users to choose by themselves.