### PR TITLE
Python 3 Compatability

### DIFF
--- a/pyad/pyadutils.py
+++ b/pyad/pyadutils.py
@@ -82,8 +82,8 @@ def convert_guid(guid_object):
     return pywintypes.IID(guid_object, True)
 
 def convert_sid(sid_object):
-    return pywintypes.SID(sid_object)
-
+    return pywintypes.SID(bytes(sid_object))
+    
 def generate_list(input):
     if type(input) is list:
         return input


### PR DESCRIPTION
raw SID returned from AD passed to Python as a memory view as buffer object is depreciated in favor of memory views. the pywin32 pywintypes.SID initializer doesn't much appreciate this change however by explicitly coercing to the python bytes object it can be satisfied and work for both 2.7 and 3.5