### PR TITLE
Python 3 Compatability

### DIFF
--- a/pyad/adobject.py
+++ b/pyad/adobject.py
@@ -179,8 +179,7 @@ class ADObject(ADBase):
 
     def __repr__(self):
         u = self.__unicode__()
-        s = u.encode("mbcs")
-        return s
+        return u
 
     def __cmp__(self, other):
         # it doesn't make sense why you'd ever have to decide


### PR DESCRIPTION
Fixes issue with printing object representations of ADObjects in Python 3 
tested on 2.7 and found no issues.