### PR TITLE
set dn value before __set_gc_adsi_obj() so that dn is not incorrect

### DIFF
--- a/pyad/adobject.py
+++ b/pyad/adobject.py
@@ -425,8 +425,8 @@ class ADObject(ADBase):
         self.__ads_path = pyadutils.generate_ads_path(new_dn, self.default_ldap_protocol,
                 self.default_ldap_server, self.default_ldap_port)
         self.__set_adsi_obj()
-        self.__set_gc_adsi_obj()
         self.__distinguished_name = self.get_attribute('distinguishedName', False)
+        self.__set_gc_adsi_obj()
 
     def rename(self, new_name, set_sAMAccountName=True):
         """Renames the current object within its current organizationalUnit.
@@ -450,8 +450,8 @@ class ADObject(ADBase):
         self.__ads_path = pyadutils.generate_ads_path(new_dn, self.default_ldap_protocol,
                 self.default_ldap_server, self.default_ldap_port)
         self.__set_adsi_obj()
-        self.__set_gc_adsi_obj()
         self.__distinguishedName = self.get_attribute('distinguishedName', False)
+        self.__set_gc_adsi_obj()
 
     def add_to_group(self, group):
         """Adds current object to the specified group.


### PR DESCRIPTION
This is for issue #27 as I was running into the same problem when running the move() method.

I moved "__set_gc_adsi_obj()" in both the "move()" and "rename()" method to be run after the objects "new dn" has been set since "__set_gc_adsi_obj()" makes a call to the objects current dn.

The way it was before, the dn of the object hadn't been updated to it's new location so "__set_gc_adsi_obj()" was raising a, "There is no such object on the server.\r\n", because it was looking for the object in its old dn.

I'm not sure if "__set_gc_adsi_obj()" has to be run before "self.__distinguished_name = self.get_attribute('distinguishedName', False)", but if it doesn't, this should fix it.