### PR TITLE
Added userAccountControl attribute

### DIFF
--- a/pyad/adcontainer.py
+++ b/pyad/adcontainer.py
@@ -77,7 +77,11 @@ class ADContainer(ADObject):
         """Create a new computer object in the container"""
         try:
             obj = self.__create_object('computer', name)
-            obj.Put('sAMAccountName', name)
+            obj.Put('sAMAccountName', name + '$')
+            if enable:
+                obj.Put('userAccountControl', 4128)
+            else:
+                obj.Put('userAccountControl', 4130)
             obj.SetInfo()
             pyadobj = ADComputer.from_com_object(obj)
             if enable:


### PR DESCRIPTION
Added userAccountControl attribute to correctly create the computer account in Active Directory.
This commit closes zakird/pyad#100

Bonus: Added tail '$' at the end of sAMAccountName attribute as a best practice.