### PR TITLE
Attempt to address #104

### DIFF
--- a/pyad/adobject.py
+++ b/pyad/adobject.py
@@ -186,7 +186,7 @@ class ADObject(ADBase):
     def __eq__(self, other):
         return isinstance(other, ADObject) and self.guid == other.guid
     
-    def __le__(self, other):
+    def __lt__(self, other):
         # it doesn't make sense why you'd ever have to decide
         # if one GUID was larger than the other,
         # but it's important to be able to know if two

--- a/pyad/adobject.py
+++ b/pyad/adobject.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from builtins import str
+from functools import total_ordering
 from . import adsearch
 from . import pyadutils
 from .adbase import *
 
+@total_ordering
 class ADObject(ADBase):
     """Python object that represents any active directory object."""
 
@@ -180,18 +182,18 @@ class ADObject(ADBase):
     def __repr__(self):
         u = self.__unicode__()
         return u
-
-    def __cmp__(self, other):
+    
+    def __eq__(self, other):
+        return isinstance(other, ADObject) and self.guid == other.guid
+    
+    def __le__(self, other):
         # it doesn't make sense why you'd ever have to decide
         # if one GUID was larger than the other,
         # but it's important to be able to know if two
         # pyAD objects represent the same AD object.
-        if (self.guid == other.guid):
-            return 0
-        elif (self.guid < other.guid):
-            return -1
-        else:
-            return 1
+        if isinstance(other, ADObject):
+            return self.guid < other.guid
+        return NotImplemented
 
     def __getattr__(self, attribute):
         # allow people to call for random attributes on the ADObject


### PR DESCRIPTION
It looks like the underlying problem is a python3 bug. It no longer checks the `__cmp__()` method, and only checks rich comparisons. This change is still compatible with older versions of Python because they will check rich comparisons when available.