### PR TITLE
fixed bug where manager is not defined

### DIFF
--- a/pyad/adobject.py
+++ b/pyad/adobject.py
@@ -466,7 +466,7 @@ class ADObject(ADBase):
     def set_managedby(self, user):
         """Sets managedBy on object to the specified user"""
         if user:
-            assert manager.__class__.__str__ == 'ADUser'
+            assert user.__class__.__str__ == 'ADUser'
             self.update_attribute('managedBy', user.dn)
         else:
             self.clear_attribute('managedBy')


### PR DESCRIPTION
Hey there!

I am pretty new to making pull requests to public repos. However for my work we built an API using pyad and a website that can manage groups and other AD objects. I was playing with some of the pyad functions and found this error trying to use the ADObject.set_managedby(ADuser) function:

![Screenshot 2020-09-29 124836](https://user-images.githubusercontent.com/55121974/94603773-f3c13a00-0253-11eb-963c-d8c4551cc7c8.png)

I did not see anywhere else where `manager` is not defined. I am assuming we want to assert that the object passed into the function is an ADUser. let me know what you think!