### PR TITLE
Add fix for issue #49

### DIFF
--- a/pyad/adquery.py
+++ b/pyad/adquery.py
@@ -36,7 +36,7 @@ class ADQuery(ADBase):
                             ADQuery.ADS_USE_ENCRYPTION
             self.__adodb_conn.Properties("ADSI Flag").Value = adsi_flag
             self.__adodb_conn.Properties("Encrypt Password").Value = True
-            self.__adodb_conn.Open("Provider=ADSDSOObject")
+            self.__adodb_conn.Open()
         else:
             self.__adodb_conn.Open("Provider=ADSDSOObject")
 


### PR DESCRIPTION
Open should be called without options if username and password are given. As far as I can see, this fix was suggested by @zakird in #49 but not implemented; at least not completely.