### PR TITLE
pywin32 dependency include

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     install_requires=[
         'setuptools',
-        'future'
+        'future',
+        'pywin32',
     ]
 )


### PR DESCRIPTION
Required for pyad to work, seems like it should be a required dependency